### PR TITLE
Added highlighting of search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ Possibility to change the role:
 
 We needed to change the `basePath` in `DefaultApi.ts` as follows
 
-    protected basePath = location.protocol + '//' + location.hostname + ':' + location.port === '4200' ? '8080' : location.port);
+    protected basePath = location.protocol + '//' + location.hostname + ':' + location.port === '4200' ? '8080' : location.port;
 
 In case you regenerate `DefaultApi.ts`, please patch this line.

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -28,16 +28,20 @@
         display: block;
         overflow: hidden;
         transition: width 0.5s ease;
+
         &.slide-right {
           width: 135px;
         }
+
         &::before {
           display: none;
         }
+
         li {
           &::before {
             display: none;
           }
+
           a {
             padding-left: 18px;
             padding-right: 18px;
@@ -119,5 +123,8 @@
     .al-footer {
       padding-left: 0;
     }
+  }
+  .search-highlight {
+    background-color: yellow;
   }
 }

--- a/frontend/src/app/pages/references/references.html
+++ b/frontend/src/app/pages/references/references.html
@@ -53,32 +53,32 @@
     </ngx-datatable-column>
     <ngx-datatable-column [width]="130" name="Type">
       <ng-template let-reference="row" ngx-datatable-cell-template>
-        {{reference.type}}
+        <span [innerHTML]="reference.type | highlight: searchInputValue"></span>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column [width]="300" name="Author/Editor">
       <ng-template let-reference="row" ngx-datatable-cell-template>
-        {{reference.authorEditor}}
+        <span [innerHTML]="reference.authorEditor | highlight: searchInputValue"></span>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column [width]="300" name="Title">
       <ng-template let-reference="row" ngx-datatable-cell-template>
-        {{reference.title}}
+        <span [innerHTML]="reference.title | highlight: searchInputValue"></span>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column [width]="60" name="Year">
       <ng-template let-reference="row" ngx-datatable-cell-template>
-        {{reference.year}}
+        <span [innerHTML]="reference.year | highlight: searchInputValue"></span>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column name="Journal/Booktitle">
       <ng-template let-reference="row" ngx-datatable-cell-template>
-        {{reference.journalBooktitle}}
+        <span [innerHTML]="reference.journalbooktitle | highlight: searchInputValue"></span>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column name="BibTeX-Key" prop="bibtexkey">
       <ng-template let-reference="row" ngx-datatable-cell-template>
-        {{reference.bibtexkey}}
+        <span [innerHTML]="reference.bibtextkey | highlight: searchInputValue"></span>
       </ng-template>
     </ngx-datatable-column>
   </ngx-datatable>

--- a/frontend/src/app/shared/HighlightPipe.ts
+++ b/frontend/src/app/shared/HighlightPipe.ts
@@ -1,0 +1,23 @@
+import { PipeTransform, Pipe } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser'
+
+@Pipe({ name: 'highlight' })
+export class HighlightPipe implements PipeTransform {
+  constructor(public sanitizer: DomSanitizer) {
+  }
+  transform(text: string, search): SafeHtml {
+    if (search && text) {
+      let pattern = search.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+      pattern = pattern.split(' ').filter((t) => {
+        return t.length > 0;
+      }).join('|');
+      const regex = new RegExp(pattern, 'gi');
+      return this.sanitizer.bypassSecurityTrustHtml(
+        text.replace(regex, (match) => `<span class="search-highlight">${match}</span>`)
+      );
+
+    } else {
+      return text;
+    }
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -3,11 +3,12 @@ import { ReferenceViewComponent } from '../pages/references/components/reference
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { HighlightPipe } from "./HighlightPipe";
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, NgbTooltipModule],
-  declarations: [ReferenceViewComponent],
-  exports: [ReferenceViewComponent, CommonModule, FormsModule],
+  declarations: [ReferenceViewComponent, HighlightPipe],
+  exports: [ReferenceViewComponent, CommonModule, FormsModule, HighlightPipe],
 })
 
 export class SharedModule { }


### PR DESCRIPTION
The search term is now being hightlighted yellow in the appropriate datagrid field.

![Result of search](https://user-images.githubusercontent.com/24602363/67230202-1ee4bc00-f43d-11e9-8b6c-b4d7257f8f0b.png)

Closes #12 