### PR TITLE
Modernize Dependabot auto-merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,20 +1,24 @@
-name: Automerge Pull Requests
-on:
-  pull_request:
-  check_suite:
-    types:
-      - completed
-  status: {}
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  automerge:
-    name: Automerge Dependabot
-    runs-on: ubuntu-latest
+  dependabot:
+    # Restrict to Dependabot's own pull requests. Only those runs receive the
+    # write-scoped token the merge step below relies on.
     if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
     steps:
-      - name: Merge pull requests
-        uses: pascalgn/automerge-action@v0.8.4
+      - name: Enable auto-merge for Dependabot PRs
+        # Turns on GitHub's native auto-merge for every Dependabot update. The
+        # PR still merges only after the required "backend" and "frontend"
+        # checks pass (branch protection on main), so a bump that breaks the
+        # build is held back automatically.
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
-          MERGE_METHOD: "squash"
-          MERGE_LABELS: ""
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
🤖

* **What kind of change does this PR introduce?**

CI / infrastructure. Modernizes the Dependabot auto-merge workflow.

* **What is the current behavior?**

`automerge.yml` uses the third-party `pascalgn/automerge-action@v0.8.4`. That action merges based on GitHub's *mergeable state* and does not reliably wait for status checks, so it both predates and races the required-checks model. With branch protection now requiring `backend` and `frontend`, the old action just errors on PRs it cannot merge (e.g. the `core-js 2→3` bump run shows a `failure`).

* **What is the new behavior (if this is a feature change)?**

Replaces it with GitHub's **native auto-merge**:

  - `gh pr merge --auto --squash` enables auto-merge on each Dependabot PR. GitHub then merges it **only after the required `backend` and `frontend` checks pass** (branch protection on `main`). All update types are auto-merged — a bump that breaks the build simply never satisfies the checks and stays open.
  - A least-privilege `permissions:` block (`contents: write`, `pull-requests: write`) replaces the broad default token.
  - Drops the third-party action (and with it, the `check_suite` / `status` triggers the old approach needed).

* **Other information**:

  - **Requires one repo setting:** enable **Settings → General → "Allow auto-merge"** (currently off), otherwise `gh pr merge --auto` errors. I could not toggle this myself (shared-repo setting). CLI equivalent: `gh api -X PATCH repos/JabRef/cloudref -F allow_auto_merge=true`.
  - This makes the open Dependabot PR **#597** (bump `pascalgn/automerge-action` to 0.16.4) obsolete; it can be closed.
  - Safety now rests entirely on the required checks. Since the frontend has no runtime tests, a bump that compiles but changes behaviour would still merge — worth keeping in mind, though that matches the requested "merge all updates" policy.
